### PR TITLE
fixClangTidyWarning

### DIFF
--- a/cpp/lqs_util.cpp
+++ b/cpp/lqs_util.cpp
@@ -280,7 +280,7 @@ class LqsUtilModule : public CPPModule
             PEntity->status = status;
         };
 
-        lua["CBaseEntity"]["setLookString"] = [](CLuaBaseEntity* PLuaBaseEntity, const std::string lookString) -> void {
+        lua["CBaseEntity"]["setLookString"] = [](CLuaBaseEntity* PLuaBaseEntity, const std::string& lookString) -> void {
             CBaseEntity* PEntity = PLuaBaseEntity->GetBaseEntity();
             PEntity->look = stringToLook(lookString);
 


### PR DESCRIPTION
The setLookString lambda function has a parameter const std::string lookString that is passed by value instead of by reference. This causes the string to be copied on every function call, which is inefficient.  It also caused a Clang Error in some cases.
<img width="1064" height="383" alt="image" src="https://github.com/user-attachments/assets/f12b6ceb-7d86-40f9-9849-c3d7b7264352" />
