### PR TITLE
Fix lqs_util build against latest LSB item API

### DIFF
--- a/cpp/lqs_util.cpp
+++ b/cpp/lqs_util.cpp
@@ -115,7 +115,7 @@ class LqsUtilModule : public CPPModule
                 return false;
             }
 
-            CItem* PItem = itemutils::GetItem(itemID);
+            const CItem* PItem = xi::items::lookup(itemID);
 
             if (PItem == nullptr)
             {
@@ -123,7 +123,7 @@ class LqsUtilModule : public CPPModule
             }
 
             // Cannot obtain if item is RARE and player already has item
-            return !((PItem->getFlag() & ITEM_FLAG_RARE) && charutils::HasItem(PChar, itemID));
+            return !(PItem->hasFlag(ItemFlag::Rare) && charutils::HasItem(PChar, itemID));
         };
 
         /************************************************************************


### PR DESCRIPTION
itemutils::GetItem was removed and the ITEM_FLAG_* macros replaced by the ItemFlag enum class in recent LandSandBoat. Use xi::items::lookup() and CItem::hasFlag(ItemFlag::Rare) so the module compiles on current LSB.