### PR TITLE
Outpost warp tavn fix

### DIFF
--- a/lib/LQS/signet.lua
+++ b/lib/LQS/signet.lua
@@ -5,6 +5,11 @@ require("modules/module_utils")
 -----------------------------------
 local m = Module:new("LQS_signet")
 
+-- Library-only module (defines LQS.signetEffect): register a no-op override
+-- so the module loader does not flag it with "No overrides found in module".
+m:addOverride("xi.dummyFunc", function()
+end)
+
 LQS = LQS or {}
 
 LQS.signetEffect = function()

--- a/lib/LQS/teleporter.lua
+++ b/lib/LQS/teleporter.lua
@@ -5,6 +5,12 @@ require("modules/module_utils")
 -----------------------------------
 local m = Module:new("LQS_teleporter")
 
+-- Library-only module (defines LQS.teleporter / LQS.outpostTeleporter): register
+-- a no-op override so the module loader does not flag it with
+-- "No overrides found in module".
+m:addOverride("xi.dummyFunc", function()
+end)
+
 LQS = LQS or {}
 
 -- Returns an onTrigger handler for use with LQS.npc.

--- a/lib/LQS/teleporter.lua
+++ b/lib/LQS/teleporter.lua
@@ -262,11 +262,11 @@ LQS.outpostTeleporter = function(config)
             costs    = { gil = data.gil, cp = data.cp },
             level    = data.level,
             check    = function(player)
-                if region == xi.region.TAVNAZIANARCH then
-                    return player:getRank(player:getNation()) >= 6
-                else
-                    return player:hasTeleport(player:getNation(), region + 5)
-                end
+                -- Outpost must be unlocked for this character. The supply-run
+                -- reward sets the region's teleport bit (region + 5); see
+                -- conquest.lua addTeleport. Tavnazia uses the same gate as every
+                -- other region rather than a flat rank requirement.
+                return player:hasTeleport(player:getNation(), region + 5)
             end,
         })
     end


### PR DESCRIPTION
the rank requirement was superseding the unlock requirement for outpost warper for Tavnazia outpost.  This fixes that.

Changes upstream require a dummy function for lua files now that dont have any functions. Added dummy functions for signet.lua and teleport.lua